### PR TITLE
fix: GASから発行されるcommandドキュメントのIDは他環境と同じく自動付番するように修正

### DIFF
--- a/command-firestore-agent.js
+++ b/command-firestore-agent.js
@@ -25,8 +25,7 @@ class CommandFirestoreAgent {
             updatedAt: new Date()
         }
         // commandコレクションに経路算出コマンドドキュメントを新規追加
-        const path = this.commandCollectionName + '/' + id;
-        this.firestore.updateDocument(path, data, true);
+        this.firestore.createDocument(this.commandCollectionName, data);
       }
     }
   }


### PR DESCRIPTION
fix #1
